### PR TITLE
Enable instantiating component multiple times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.1.0]
+### Added
+
+- Support for multiple instantiation ([#4])
+
 ## [v1.0.0]
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v1.1.0]
+## [v2.0.0]
 ### Added
 
 - Support for multiple instantiation ([#4])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support for multiple instantiation ([#4])
 
+### Changed
+
+- Update helm chart to version 4.0.6
+- The parameter `release_name` is now instance-specific by default
+
+
 ## [v1.0.0]
 ### Added
 

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -1,6 +1,7 @@
 parameters:
   nfs_subdir_external_provisioner:
     namespace: syn-nfs-subdir-external-provisioner
+    multi_instance: true
     release_name: platform
     helm_values:
       storageClass:

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -2,7 +2,7 @@ parameters:
   nfs_subdir_external_provisioner:
     namespace: syn-nfs-subdir-external-provisioner
     multi_instance: true
-    release_name: platform
+    release_name: ${_instance}
     helm_values:
       storageClass:
         accessModes: ReadWriteMany

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -7,4 +7,4 @@ parameters:
       storageClass:
         accessModes: ReadWriteMany
     charts:
-      nfs_subdir_external_provisioner: 4.0.1
+      nfs_subdir_external_provisioner: 4.0.6

--- a/class/nfs-subdir-external-provisioner.yml
+++ b/class/nfs-subdir-external-provisioner.yml
@@ -10,12 +10,12 @@ parameters:
       - input_paths:
           - nfs-subdir-external-provisioner/component/app.jsonnet
         input_type: jsonnet
-        output_path: apps/
+        output_path: apps/${_instance}
       - input_paths:
           - nfs-subdir-external-provisioner/component/main.jsonnet
         input_type: jsonnet
-        output_path: nfs-subdir-external-provisioner/
-      - output_path: nfs-subdir-external-provisioner/01_helmchart
+        output_path: nfs-subdir-external-provisioner/${_instance}
+      - output_path: nfs-subdir-external-provisioner/${_instance}/01_helmchart
         input_type: helm
         input_paths:
           - nfs-subdir-external-provisioner/helmcharts/nfs-subdir-external-provisioner

--- a/class/nfs-subdir-external-provisioner.yml
+++ b/class/nfs-subdir-external-provisioner.yml
@@ -10,11 +10,11 @@ parameters:
       - input_paths:
           - nfs-subdir-external-provisioner/component/app.jsonnet
         input_type: jsonnet
-        output_path: apps/${_instance}
+        output_path: apps/
       - input_paths:
           - nfs-subdir-external-provisioner/component/main.jsonnet
         input_type: jsonnet
-        output_path: nfs-subdir-external-provisioner/${_instance}
+        output_path: nfs-subdir-external-provisioner/
       - output_path: nfs-subdir-external-provisioner/${_instance}/01_helmchart
         input_type: helm
         input_paths:

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -2,6 +2,8 @@
 
 nfs-subdir-external-provisioner is a Commodore component to manage nfs-subdir-external-provisioner.
 
+nfs-subdir-external-provisioner supports instantiating the component multiple times (see https://syn.tools/commodore/reference/architecture.html#_component_instantiation[Project Syn Documentation] for details).
+
 The Kubernetes NFS Subdir External Provisioner is the successor of the former Kubernetes NFS-Client Provisioner project.
 
 See the xref:references/parameters.adoc[parameters] reference for further details.

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -2,7 +2,7 @@
 
 nfs-subdir-external-provisioner is a Commodore component to manage nfs-subdir-external-provisioner.
 
-nfs-subdir-external-provisioner supports instantiating the component multiple times (see https://syn.tools/commodore/reference/architecture.html#_component_instantiation[Project Syn Documentation] for details).
+nfs-subdir-external-provisioner supports instantiating the component multiple times (see https://syn.tools/commodore/reference/architecture.html#_component_instantiation[Project Syn documentation] for details).
 
 The Kubernetes NFS Subdir External Provisioner is the successor of the former Kubernetes NFS-Client Provisioner project.
 

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -15,17 +15,17 @@ The namespace in which to deploy this component.
 
 [horizontal]
 type:: string
-default:: `plattform`
+default:: `${_instance}`
 
 The name syn-nfs-subdir-external-provisioner is deployed.
-Usually there is just one deployment and therefore no change is required.
+By default, the commodore meta-parameter `parameters._instance` is used. `parameters._instance` is set to the aliased name used for instantiation or the component name for non-aliased instances.
 
 
 == `charts.nfs_subdir_external_provisioner`
 
 [horizontal]
 type:: string
-default:: `4.0.1`
+default:: `4.0.6`
 
 The helm chart version going to be used.
 


### PR DESCRIPTION
- Enable instantiating component multiple times as described in https://syn.tools/commodore/reference/architecture.html#_component_instantiation
- use newest helm chart version 4.0.6

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update the ./CHANGELOG.md.