### PR TITLE
Openshift SCC object to mount nfs volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v2.1.0]
+### Added
+
+- Security context constraints object for openshift that allows mounting of nfs volumes
+
+
 ## [v2.0.0]
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v2.1.0]
 ### Added
 
-- Security context constraints object for openshift that allows mounting of nfs volumes
+- Security context constraints object for openshift that allows mounting of nfs volumes [#5]
 
 
 ## [v2.0.0]
@@ -28,5 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased]: https://github.com/projectsyn/component-nfs-subdir-external-provisioner/compare/v1.0.0...HEAD
 [v1.0.0]: https://github.com/projectsyn/component-nfs-subdir-external-provisioner/releases/tag/v1.0.0
+[v2.0.0]: https://github.com/projectsyn/component-nfs-subdir-external-provisioner/releases/tag/v2.0.0
+[v2.1.0]: https://github.com/projectsyn/component-nfs-subdir-external-provisioner/releases/tag/v2.1.0
 
 [#1]: https://github.com/projectsyn/component-nfs-subdir-external-provisioner/pull/1
+[#4]: https://github.com/projectsyn/component-nfs-subdir-external-provisioner/pull/4
+[#5]: https://github.com/projectsyn/component-nfs-subdir-external-provisioner/pull/5

--- a/class/nfs-subdir-external-provisioner.yml
+++ b/class/nfs-subdir-external-provisioner.yml
@@ -15,6 +15,10 @@ parameters:
           - nfs-subdir-external-provisioner/component/main.jsonnet
         input_type: jsonnet
         output_path: nfs-subdir-external-provisioner/
+      - input_paths:
+          - nfs-subdir-external-provisioner/component/openshiftscc.jsonnet
+        input_type: jsonnet
+        output_path: nfs-subdir-external-provisioner/${_instance}/
       - output_path: nfs-subdir-external-provisioner/${_instance}/01_helmchart
         input_type: helm
         input_paths:

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -5,7 +5,50 @@ local inv = kap.inventory();
 // The hiera parameters for the component
 local params = inv.parameters.nfs_subdir_external_provisioner;
 
+
+local isOpenshift = std.startsWith(inv.parameters.facts.distribution, 'openshift');
+local instance = inv.parameters._instance;
+
+local nfsMountScc = {
+  apiVersion: 'security.openshift.io/v1',
+  kind: 'SecurityContextConstraints',
+  metadata: {
+   name: 'hostmount-anyuid-nfs-subdir-external-provisioner-scc',
+   namespace: params.namespace,
+  },
+  users: [
+    'system:serviceaccount:' + params.namespace + ':' + instance,
+  ],
+  volumes: [
+    'configMap',
+    'emptyDir',
+    'nfs',
+    'persistentVolumeClaim',
+    'secret'
+  ],
+  allowHostDirVolumePlugin: true,
+  allowHostIPC: false,
+  allowHostNetwork: false,
+  allowHostPID: false,
+  allowHostPorts: false,
+  allowPrivilegeEscalation: true,
+  allowPrivilegedContainer: false,
+  fsGroup: {
+    type: 'RunAsAny',
+  },
+  runAsUser: {
+    type: 'RunAsAny',
+  },
+  seLinuxContext: {
+    type: 'MustRunAs',
+  },
+  supplementalyGroups: {
+    type: 'RunAsAny',
+  },
+};
+
 // Define outputs below
 {
   '00_namespace': kube.Namespace(params.namespace),
+  [if isOpenshift then '02_hostmount-anyuid-nfs-subdir-external-provisioner-scc']: nfsMountScc,
 }

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -5,50 +5,7 @@ local inv = kap.inventory();
 // The hiera parameters for the component
 local params = inv.parameters.nfs_subdir_external_provisioner;
 
-
-local isOpenshift = std.startsWith(inv.parameters.facts.distribution, 'openshift');
-local instance = inv.parameters._instance;
-
-local nfsMountScc = {
-  apiVersion: 'security.openshift.io/v1',
-  kind: 'SecurityContextConstraints',
-  metadata: {
-    name: 'hostmount-anyuid-nfs-subdir-external-provisioner-scc',
-    namespace: params.namespace,
-  },
-  users: [
-    'system:serviceaccount:' + params.namespace + ':' + instance,
-  ],
-  volumes: [
-    'configMap',
-    'emptyDir',
-    'nfs',
-    'persistentVolumeClaim',
-    'secret',
-  ],
-  allowHostDirVolumePlugin: true,
-  allowHostIPC: false,
-  allowHostNetwork: false,
-  allowHostPID: false,
-  allowHostPorts: false,
-  allowPrivilegeEscalation: true,
-  allowPrivilegedContainer: false,
-  fsGroup: {
-    type: 'RunAsAny',
-  },
-  runAsUser: {
-    type: 'RunAsAny',
-  },
-  seLinuxContext: {
-    type: 'MustRunAs',
-  },
-  supplementalyGroups: {
-    type: 'RunAsAny',
-  },
-};
-
 // Define outputs below
 {
   '00_namespace': kube.Namespace(params.namespace),
-  [if isOpenshift then '02_hostmount-anyuid-nfs-subdir-external-provisioner-scc']: nfsMountScc,
 }

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -13,8 +13,8 @@ local nfsMountScc = {
   apiVersion: 'security.openshift.io/v1',
   kind: 'SecurityContextConstraints',
   metadata: {
-   name: 'hostmount-anyuid-nfs-subdir-external-provisioner-scc',
-   namespace: params.namespace,
+    name: 'hostmount-anyuid-nfs-subdir-external-provisioner-scc',
+    namespace: params.namespace,
   },
   users: [
     'system:serviceaccount:' + params.namespace + ':' + instance,
@@ -24,7 +24,7 @@ local nfsMountScc = {
     'emptyDir',
     'nfs',
     'persistentVolumeClaim',
-    'secret'
+    'secret',
   ],
   allowHostDirVolumePlugin: true,
   allowHostIPC: false,

--- a/component/openshiftscc.jsonnet
+++ b/component/openshiftscc.jsonnet
@@ -16,7 +16,7 @@ local nfsMountScc = {
     namespace: params.namespace,
     labels: {
       'app.kubernetes.io/name': 'hostmount-anyuid-' + instance,
-      'app.kubernetes.io/instance': 'hostmount-anyuid-' + instance,
+      'app.kubernetes.io/instance': instance,
       'app.kubernetes.io/component': 'nfs-subdir-external-provisioner',
       'app.kubernetes.io/managed-by': 'syn',
     },

--- a/component/openshiftscc.jsonnet
+++ b/component/openshiftscc.jsonnet
@@ -1,0 +1,52 @@
+// instance-specific security context constraint object for openshift
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+local inv = kap.inventory();
+// The hiera parameters for the component
+local params = inv.parameters.nfs_subdir_external_provisioner;
+
+local isOpenshift = std.startsWith(inv.parameters.facts.distribution, 'openshift');
+local instance = inv.parameters._instance;
+
+local nfsMountScc = {
+  apiVersion: 'security.openshift.io/v1',
+  kind: 'SecurityContextConstraints',
+  metadata: {
+    name: 'hostmount-anyuid-scc-' + instance,
+    namespace: params.namespace,
+  },
+  users: [
+    'system:serviceaccount:' + params.namespace + ':' + instance,
+  ],
+  volumes: [
+    'configMap',
+    'emptyDir',
+    'nfs',
+    'persistentVolumeClaim',
+    'secret',
+  ],
+  allowHostDirVolumePlugin: true,
+  allowHostIPC: false,
+  allowHostNetwork: false,
+  allowHostPID: false,
+  allowHostPorts: false,
+  allowPrivilegeEscalation: true,
+  allowPrivilegedContainer: false,
+  fsGroup: {
+    type: 'RunAsAny',
+  },
+  runAsUser: {
+    type: 'RunAsAny',
+  },
+  seLinuxContext: {
+    type: 'MustRunAs',
+  },
+  supplementalyGroups: {
+    type: 'RunAsAny',
+  },
+};
+
+// Define outputs below
+{
+  [if isOpenshift then '02_hostmount-anyuid-scc']: nfsMountScc,
+}

--- a/component/openshiftscc.jsonnet
+++ b/component/openshiftscc.jsonnet
@@ -41,7 +41,7 @@ local nfsMountScc = {
   seLinuxContext: {
     type: 'MustRunAs',
   },
-  supplementalyGroups: {
+  supplementaryGroups: {
     type: 'RunAsAny',
   },
 };

--- a/component/openshiftscc.jsonnet
+++ b/component/openshiftscc.jsonnet
@@ -16,6 +16,8 @@ local nfsMountScc = {
     namespace: params.namespace,
     labels: {
       'app.kubernetes.io/name': 'hostmount-anyuid-' + instance,
+      'app.kubernetes.io/instance': 'hostmount-anyuid-' + instance,
+      'app.kubernetes.io/component': 'nfs-subdir-external-provisioner',
       'app.kubernetes.io/managed-by': 'syn',
     },
   },

--- a/component/openshiftscc.jsonnet
+++ b/component/openshiftscc.jsonnet
@@ -12,7 +12,7 @@ local nfsMountScc = {
   apiVersion: 'security.openshift.io/v1',
   kind: 'SecurityContextConstraints',
   metadata: {
-    name: 'hostmount-anyuid-scc-' + instance,
+    name: 'hostmount-anyuid-' + instance,
     namespace: params.namespace,
   },
   users: [

--- a/component/openshiftscc.jsonnet
+++ b/component/openshiftscc.jsonnet
@@ -14,6 +14,10 @@ local nfsMountScc = {
   metadata: {
     name: 'hostmount-anyuid-' + instance,
     namespace: params.namespace,
+    labels: {
+      'app.kubernetes.io/name': 'hostmount-anyuid-' + instance,
+      'app.kubernetes.io/managed-by': 'syn',
+    },
   },
   users: [
     'system:serviceaccount:' + params.namespace + ':' + instance,

--- a/component/openshiftscc.jsonnet
+++ b/component/openshiftscc.jsonnet
@@ -41,9 +41,10 @@ local nfsMountScc = {
   seLinuxContext: {
     type: 'MustRunAs',
   },
-  supplementaryGroups: {
+  supplementalGroups: {
     type: 'RunAsAny',
   },
+  readOnlyRootFilesystem: false,
 };
 
 // Define outputs below


### PR DESCRIPTION
This PR adds a security context constraint object for openshift distributions, which allows mounting of nfs volumes.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation.
- [x] Update the ./CHANGELOG.md.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
