### PR TITLE
Add hostPath to the list of allowed volumes of the SCC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v2.1.1]
+### Added
+
+- Add `hostPath` to the list of allowed volumes of the Openshift security context constraint objects [#6]
+
 ## [v2.1.0]
 ### Added
 
@@ -34,3 +39,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1]: https://github.com/projectsyn/component-nfs-subdir-external-provisioner/pull/1
 [#4]: https://github.com/projectsyn/component-nfs-subdir-external-provisioner/pull/4
 [#5]: https://github.com/projectsyn/component-nfs-subdir-external-provisioner/pull/5
+[#6]: https://github.com/projectsyn/component-nfs-subdir-external-provisioner/pull/6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v2.1.0]: https://github.com/projectsyn/component-nfs-subdir-external-provisioner/releases/tag/v2.1.0
 [v2.1.1]: https://github.com/projectsyn/component-nfs-subdir-external-provisioner/releases/tag/v2.1.1
 
-
 [#1]: https://github.com/projectsyn/component-nfs-subdir-external-provisioner/pull/1
 [#4]: https://github.com/projectsyn/component-nfs-subdir-external-provisioner/pull/4
 [#5]: https://github.com/projectsyn/component-nfs-subdir-external-provisioner/pull/5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v2.1.1]
 ### Added
 
-- Add `hostPath` to the list of allowed volumes of the Openshift security context constraint objects [#6]
+- Add `hostPath` to the list of allowed volumes of the Openshift security context constraint objects ([#6])
 
 ## [v2.1.0]
 ### Added
 
-- Security context constraints object for openshift that allows mounting of nfs volumes [#5]
+- Security context constraints object for openshift that allows mounting of nfs volumes ([#5])
 
 
 ## [v2.0.0]
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v1.0.0]: https://github.com/projectsyn/component-nfs-subdir-external-provisioner/releases/tag/v1.0.0
 [v2.0.0]: https://github.com/projectsyn/component-nfs-subdir-external-provisioner/releases/tag/v2.0.0
 [v2.1.0]: https://github.com/projectsyn/component-nfs-subdir-external-provisioner/releases/tag/v2.1.0
+[v2.1.1]: https://github.com/projectsyn/component-nfs-subdir-external-provisioner/releases/tag/v2.1.1
+
 
 [#1]: https://github.com/projectsyn/component-nfs-subdir-external-provisioner/pull/1
 [#4]: https://github.com/projectsyn/component-nfs-subdir-external-provisioner/pull/4

--- a/component/openshiftscc.jsonnet
+++ b/component/openshiftscc.jsonnet
@@ -28,6 +28,7 @@ local nfsMountScc = {
     'configMap',
     'emptyDir',
     'nfs',
+    'hostPath',
     'persistentVolumeClaim',
     'secret',
   ],


### PR DESCRIPTION
Openshift adds hostPath to the list of allowed volumes, because
allowHostDirVolumePlugin overrides settings in volumes for backwards
compatibility. This leads to ArgoCD endlessly recreating the SCC object,
because there's a mismatch between desired and live manifest.

Openshift Docs: https://docs.openshift.com/container-platform/4.7/authentication/managing-security-context-constraints.html#authorization-controlling-volumes_configuring-internal-oauth

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the ./CHANGELOG.md.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
