### PR TITLE
Alphabetical order for allowed volumes in SCC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v2.1.2]
+### Changed
+
+- Correct alphabetical order of allowed volumes ([#7])
+
 ## [v2.1.1]
 ### Added
 
@@ -36,8 +41,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v2.0.0]: https://github.com/projectsyn/component-nfs-subdir-external-provisioner/releases/tag/v2.0.0
 [v2.1.0]: https://github.com/projectsyn/component-nfs-subdir-external-provisioner/releases/tag/v2.1.0
 [v2.1.1]: https://github.com/projectsyn/component-nfs-subdir-external-provisioner/releases/tag/v2.1.1
+[v2.1.2]: https://github.com/projectsyn/component-nfs-subdir-external-provisioner/releases/tag/v2.1.2
 
 [#1]: https://github.com/projectsyn/component-nfs-subdir-external-provisioner/pull/1
 [#4]: https://github.com/projectsyn/component-nfs-subdir-external-provisioner/pull/4
 [#5]: https://github.com/projectsyn/component-nfs-subdir-external-provisioner/pull/5
 [#6]: https://github.com/projectsyn/component-nfs-subdir-external-provisioner/pull/6
+[#7]: https://github.com/projectsyn/component-nfs-subdir-external-provisioner/pull/7

--- a/component/openshiftscc.jsonnet
+++ b/component/openshiftscc.jsonnet
@@ -27,8 +27,8 @@ local nfsMountScc = {
   volumes: [
     'configMap',
     'emptyDir',
-    'nfs',
     'hostPath',
+    'nfs',
     'persistentVolumeClaim',
     'secret',
   ],


### PR DESCRIPTION
Fixes mismatch between desired and live manifests in ArgoCD due to wrong (not alphabetical) order of allowed volumes
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the ./CHANGELOG.md.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
