### PR TITLE
Rename variable release_name to name

### DIFF
--- a/class/nfs-subdir-external-provisioner.yml
+++ b/class/nfs-subdir-external-provisioner.yml
@@ -24,6 +24,6 @@ parameters:
         input_paths:
           - nfs-subdir-external-provisioner/helmcharts/nfs-subdir-external-provisioner
         helm_params:
-          release_name: ${nfs_subdir_external_provisioner:release_name}
+          name: ${nfs_subdir_external_provisioner:release_name}
           namespace: ${nfs_subdir_external_provisioner:namespace}
         helm_values: ${nfs_subdir_external_provisioner:helm_values}


### PR DESCRIPTION
Kapitan has changed the naming and release_name is now deprecated.

## Checklist

- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
