### PR TITLE
Remove workaround to pull container image from registry.k8s.io

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -5,9 +5,6 @@ parameters:
     namespace: syn-nfs-subdir-external-provisioner
     release_name: ${_instance}
     helm_values:
-      image:
-        # Workaround until https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/pull/252 has been merged
-        repository: registry.k8s.io/sig-storage/nfs-subdir-external-provisioner
       storageClass:
         accessModes: ReadWriteMany
     charts:


### PR DESCRIPTION
Configure the registry.k8s.io manually is no longer required. The upstream patch has been accepted and released in the helm chart version 4.0.18.

Reference:
* https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/pull/252

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
